### PR TITLE
Fix current song color not loading

### DIFF
--- a/app/src/main/java/com/loafofpiecrust/turntable/player/MusicService.kt
+++ b/app/src/main/java/com/loafofpiecrust/turntable/player/MusicService.kt
@@ -70,9 +70,12 @@ class MusicService : BaseService(), OnAudioFocusChangeListener {
             .map(Dispatchers.Main) { (song, req) ->
                 if (req == null) {
                     null
-                } else suspendCoroutine { cont ->
+                } else suspendCoroutine<PickedSwatch?> { cont ->
                     req.addListener(loadPalette(song.id) { palette, swatch ->
-                        PickedSwatch(palette!!, swatch!!)
+                        val p = if (palette != null && swatch != null) {
+                            PickedSwatch(palette, swatch)
+                        } else null
+                        cont.resume(p)
                     }).preload()
                 }
             }


### PR DESCRIPTION
This PR fixes the globally provided `currentSongColor` that allows any element in the app to embody the album art of the currently playing song.

Resolves #121 .