### PR TITLE
Use immutable collections for more efficient channels

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -93,6 +93,9 @@ android {
         sourceCompatibility JavaVersion.VERSION_1_8
         targetCompatibility JavaVersion.VERSION_1_8
     }
+    kotlinOptions {
+        jvmTarget = JavaVersion.VERSION_1_8
+    }
 
     sourceSets {
         main.java.srcDirs += 'src/main/kotlin'
@@ -267,8 +270,6 @@ dependencies {
     implementation "com.android.support:cardview-v7:$android_ver"
     testImplementation "com.android.support.test:runner:1.0.2"
 
-    implementation 'com.github.andrewoma.dexx:kollection:0.7'
-
 
     //    implementation "eu.davidea:flexible-adapter:5.0.5"
 
@@ -300,5 +301,6 @@ dependencies {
     implementation "org.jetbrains.kotlin:kotlin-stdlib:$kotlin_version"
 //    implementation "org.jetbrains.kotlin:kotlin-reflect:$kotlin_version"
     implementation "org.jetbrains.kotlinx:kotlinx-serialization-runtime:$serialization_version"
+    implementation 'org.jetbrains.kotlinx:kotlinx-collections-immutable:0.1'
 }
 apply plugin: 'com.google.gms.google-services'

--- a/app/src/main/java/com/loafofpiecrust/turntable/App.kt
+++ b/app/src/main/java/com/loafofpiecrust/turntable/App.kt
@@ -180,13 +180,10 @@ class App: Application() {
             MessageReceiverService.messages
         )
 
-        runBlocking {
-            UserPrefs.lastOpenTime puts UserPrefs.currentOpenTime.openSubscription().first()
-            UserPrefs.currentOpenTime puts System.currentTimeMillis()
-        }
-
         // Initial internet status
         launch {
+            UserPrefs.lastOpenTime puts UserPrefs.currentOpenTime.openSubscription().first()
+            UserPrefs.currentOpenTime puts System.currentTimeMillis()
             delay(300)
             watchConnectionStatus()
         }

--- a/app/src/main/java/com/loafofpiecrust/turntable/ViewUtils.kt
+++ b/app/src/main/java/com/loafofpiecrust/turntable/ViewUtils.kt
@@ -18,6 +18,7 @@ import com.github.salomonbrys.kotson.jsonNull
 import com.github.salomonbrys.kotson.registerTypeAdapter
 import com.google.gson.GsonBuilder
 import com.loafofpiecrust.turntable.util.hasValue
+import kotlinx.collections.immutable.ImmutableList
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.Deferred
 import kotlinx.coroutines.GlobalScope

--- a/app/src/main/java/com/loafofpiecrust/turntable/browse/BrowseFragment.kt
+++ b/app/src/main/java/com/loafofpiecrust/turntable/browse/BrowseFragment.kt
@@ -26,6 +26,7 @@ import com.loafofpiecrust.turntable.util.menuItem
 import com.loafofpiecrust.turntable.util.onClick
 import com.loafofpiecrust.turntable.views.RecyclerAdapter
 import com.loafofpiecrust.turntable.views.RecyclerListItem
+import kotlinx.collections.immutable.immutableListOf
 import kotlinx.coroutines.channels.ReceiveChannel
 import kotlinx.coroutines.channels.map
 import org.jetbrains.anko.*
@@ -40,7 +41,7 @@ import kotlin.coroutines.CoroutineContext
 class BrowseFragment: BaseFragment() {
     override fun Menu.createOptions() {
         menuItem("Clear", R.drawable.ic_cake, showIcon = false).onClick {
-            UserPrefs.recommendations puts emptyList()
+            UserPrefs.recommendations puts immutableListOf()
         }
     }
 

--- a/app/src/main/java/com/loafofpiecrust/turntable/browse/RecommendationsUI.kt
+++ b/app/src/main/java/com/loafofpiecrust/turntable/browse/RecommendationsUI.kt
@@ -13,6 +13,7 @@ import com.loafofpiecrust.turntable.util.menuItem
 import com.loafofpiecrust.turntable.util.onClick
 import com.loafofpiecrust.turntable.views.refreshableRecyclerView
 import kotlinx.android.parcel.Parcelize
+import kotlinx.collections.immutable.immutableListOf
 import org.jetbrains.anko.alert
 import org.jetbrains.anko.cancelButton
 import org.jetbrains.anko.recyclerview.v7.recyclerView
@@ -48,7 +49,7 @@ class RecommendationsUI: UIComponent(), Parcelable {
                 title = "Clear Recommendations"
                 message = "Are you sure?"
                 positiveButton("Clear") {
-                    UserPrefs.recommendations.offer(emptyList())
+                    UserPrefs.recommendations.offer(immutableListOf())
                 }
                 cancelButton {}
             }.show()

--- a/app/src/main/java/com/loafofpiecrust/turntable/model/song/Song.kt
+++ b/app/src/main/java/com/loafofpiecrust/turntable/model/song/Song.kt
@@ -133,11 +133,11 @@ data class Song(
                 hqUrl: String?,
                 expiryDate: Long = System.currentTimeMillis() + 6.hours.toMillis().toLong()
             ): Media {
-                val sources = mutableListOf(
-                    Source(lqUrl, Quality.LOW)
-                )
-                if (hqUrl != null) {
-                    sources.add(Source(hqUrl, Quality.MEDIUM))
+                val lq = Source(lqUrl, Quality.LOW)
+                val sources = if (hqUrl != null) {
+                    listOf(lq, Source(hqUrl, Quality.MEDIUM))
+                } else {
+                    listOf(lq)
                 }
                 return Media(sources, expiryDate)
             }

--- a/app/src/main/java/com/loafofpiecrust/turntable/model/sync/Message.kt
+++ b/app/src/main/java/com/loafofpiecrust/turntable/model/sync/Message.kt
@@ -10,6 +10,7 @@ import com.loafofpiecrust.turntable.model.song.Song
 import com.loafofpiecrust.turntable.player.MusicPlayer
 import com.loafofpiecrust.turntable.player.MusicService
 import com.loafofpiecrust.turntable.prefs.UserPrefs
+import com.loafofpiecrust.turntable.putsMapped
 import com.loafofpiecrust.turntable.util.Duration
 import com.loafofpiecrust.turntable.util.days
 import com.loafofpiecrust.turntable.util.minutes
@@ -33,14 +34,18 @@ interface Message {
     ): Message {
         override val timeout get() = 28.days
         override suspend fun onReceive(sender: User) {
-            UserPrefs.recommendations appends content
+            UserPrefs.recommendations putsMapped {
+                it.add(content)
+            }
         }
     }
 
     data class Playlist(val id: UUID): Message {
         override suspend fun onReceive(sender: User) {
-            AbstractPlaylist.find(id)?.let {
-                UserPrefs.recommendations appends it.id
+            AbstractPlaylist.find(id)?.let { pl ->
+                UserPrefs.recommendations putsMapped { recs ->
+                    recs.add(pl.id)
+                }
             }
         }
     }

--- a/app/src/main/java/com/loafofpiecrust/turntable/player/MusicPlayer.kt
+++ b/app/src/main/java/com/loafofpiecrust/turntable/player/MusicPlayer.kt
@@ -26,6 +26,7 @@ import com.loafofpiecrust.turntable.util.startWith
 import com.loafofpiecrust.turntable.util.with
 import com.loafofpiecrust.turntable.util.without
 import io.paperdb.Paper
+import kotlinx.collections.immutable.immutableListOf
 import kotlinx.coroutines.*
 import kotlinx.coroutines.channels.ConflatedBroadcastChannel
 import kotlinx.coroutines.channels.ReceiveChannel
@@ -179,9 +180,12 @@ class MusicPlayer(ctx: Context): Player.EventListener, CoroutineScope {
         // if that fails the 2nd time, skip to the next track in the MediaSource.
         if (error.type == ExoPlaybackException.TYPE_SOURCE) {
             App.instance.toast("Song not available to stream")
-            // to retry, we have to rebuild the MediaSource
-            playNext()
-            prepareSource()
+            launch {
+                delay(100)
+                // to retry, we have to rebuild the MediaSource
+                playNext()
+                prepareSource()
+            }
         } else {
             App.instance.toast("Dubious player error (type ${error.type})")
         }
@@ -253,7 +257,7 @@ class MusicPlayer(ctx: Context): Player.EventListener, CoroutineScope {
 //                    if (q.isPlayingNext) q.nextUp.drop(1) else q.nextUp
 //                } else listOf()
 
-                _queue.offer(CombinedQueue(primary, listOf()))
+                _queue.offer(CombinedQueue(primary, immutableListOf()))
             }
             OrderMode.SHUFFLE -> {
                 nonShuffledQueue = StaticQueue(songs, position)
@@ -297,7 +301,7 @@ class MusicPlayer(ctx: Context): Player.EventListener, CoroutineScope {
 
     fun clearQueue() {
         nonShuffledQueue = null
-        _queue puts CombinedQueue(StaticQueue(listOf(), 0), listOf())
+        _queue puts CombinedQueue(StaticQueue(listOf(), 0), immutableListOf())
         mediaSource?.clear()
         player.stop()
     }
@@ -485,7 +489,9 @@ class MusicPlayer(ctx: Context): Player.EventListener, CoroutineScope {
         val percent = total.toDouble() / player.duration
         if (percent > LISTENED_PROPORTION) {
             // TODO: Add timestamp and percent to history entries
-            UserPrefs.history appends HistoryEntry(_queue.value.current!!)
+            UserPrefs.history putsMapped {
+                it.add(HistoryEntry(_queue.value.current!!))
+            }
         }
         totalListenedTime = 0
     }

--- a/app/src/main/java/com/loafofpiecrust/turntable/playlist/PlaylistDetailsUI.kt
+++ b/app/src/main/java/com/loafofpiecrust/turntable/playlist/PlaylistDetailsUI.kt
@@ -121,7 +121,7 @@ class PlaylistDetailsUI(
                         positiveButton(R.string.playlist_delete) {
                             GlobalScope.launch {
                                 UserPrefs.playlists putsMapped {
-                                    it.withoutFirst { it.id.uuid == playlistId.uuid }
+                                    it.removeAll { it.id.uuid == playlistId.uuid }
                                 }
                             }
                             ctx.popMainContent()

--- a/app/src/main/java/com/loafofpiecrust/turntable/playlist/PlaylistMenu.kt
+++ b/app/src/main/java/com/loafofpiecrust/turntable/playlist/PlaylistMenu.kt
@@ -74,7 +74,7 @@ fun Toolbar.playlistOptions(
             positiveButton(R.string.playlist_delete) {
                 GlobalScope.launch {
                     UserPrefs.playlists putsMapped {
-                        it.withoutFirst { it.id.uuid == playlist.id.uuid }
+                        it.removeAll { it.id.uuid == playlist.id.uuid }
                     }
                 }
                 ctx.popMainContent()

--- a/app/src/main/java/com/loafofpiecrust/turntable/playlist/PlaylistsFragment.kt
+++ b/app/src/main/java/com/loafofpiecrust/turntable/playlist/PlaylistsFragment.kt
@@ -93,7 +93,7 @@ class PlaylistsFragment: BaseFragment() {
                             val tracks = runBlocking { pl.ok.resolveTracks() }
                             "Loaded playlist $tracks"
                         }
-                        UserPrefs.playlists appends pl.ok
+                        UserPrefs.playlists putsMapped { it.add(pl.ok) }
                     }
                     is Result.Error -> launch(Dispatchers.Main) {
                         Timber.e(pl.error) { "Failed to load Spotify playlist" }
@@ -152,7 +152,10 @@ class PlaylistsFragment: BaseFragment() {
 
         override fun canMoveItem(index: Int) = true
         override fun onItemMove(fromIdx: Int, toIdx: Int) {
-            UserPrefs.playlists putsMapped { it.shifted(fromIdx, toIdx) }
+            UserPrefs.playlists putsMapped { playlists ->
+                val pl = playlists[fromIdx]
+                playlists.removeAt(fromIdx).add(toIdx, pl)
+            }
         }
 
         override fun onCreateViewHolder(parent: ViewGroup, viewType: Int) =

--- a/app/src/main/java/com/loafofpiecrust/turntable/prefs/UserPrefs.kt
+++ b/app/src/main/java/com/loafofpiecrust/turntable/prefs/UserPrefs.kt
@@ -14,6 +14,7 @@ import com.loafofpiecrust.turntable.serialize.page
 import com.loafofpiecrust.turntable.service.Library
 import com.loafofpiecrust.turntable.util.getColorCompat
 import io.paperdb.Paper
+import kotlinx.collections.immutable.immutableListOf
 
 /**
  * Never change any of the string keys used here.
@@ -59,9 +60,15 @@ object UserPrefs: KotprefModel() {
     val sdCardUri by Paper.page("sdCardUri") { "" }
 
     // Metadata (saves to files rather than SharedPreferences to reduce memory usage)
-    val history by Paper.page("history") { listOf<HistoryEntry>() }
-    val playlists by Paper.page("playlists") { listOf<Playlist>() }
-    val recommendations by Paper.page("recommendations") { listOf<Recommendable>() }
+    val history by Paper.page("history") {
+        immutableListOf<HistoryEntry>()
+    }
+    val playlists by Paper.page("playlists") {
+        immutableListOf<Playlist>()
+    }
+    val recommendations by Paper.page("recommendations") {
+        immutableListOf<Recommendable>()
+    }
 
     val lastOpenTime by longPref(System.currentTimeMillis(), "lastOpenTime")
     val currentOpenTime by longPref(System.currentTimeMillis(), "currentOpenTime")

--- a/app/src/main/java/com/loafofpiecrust/turntable/repository/local/SearchCache.kt
+++ b/app/src/main/java/com/loafofpiecrust/turntable/repository/local/SearchCache.kt
@@ -13,11 +13,8 @@ object SearchCache: Repository {
     private const val CACHE_COUNT = 25
 
     override suspend fun searchArtists(query: String) = emptyList<Artist>()
-
     override suspend fun searchAlbums(query: String) = emptyList<Album>()
-
     override suspend fun searchSongs(query: String) = emptyList<Song>()
-
 
     private fun <K, T> MutableMap<K, T>.cache(key: K, value: T) {
         if (size >= CACHE_COUNT) {

--- a/app/src/main/java/com/loafofpiecrust/turntable/serialize/ImmutableListTypeAdapter.kt
+++ b/app/src/main/java/com/loafofpiecrust/turntable/serialize/ImmutableListTypeAdapter.kt
@@ -1,0 +1,77 @@
+package com.loafofpiecrust.turntable.serialize
+
+import com.github.salomonbrys.kotson.*
+import com.google.gson.*
+import com.loafofpiecrust.turntable.util.lazy
+import kotlinx.collections.immutable.*
+import java.lang.reflect.ParameterizedType
+import java.lang.reflect.Type
+
+
+class ImmutableListTypeAdapter<T: Any>: JsonSerializer<ImmutableList<T>>, JsonDeserializer<ImmutableList<T>> {
+    override fun serialize(src: ImmutableList<T>, typeOfSrc: Type, context: JsonSerializationContext): JsonElement {
+        val par = typeOfSrc as ParameterizedType
+        val innerType = par.actualTypeArguments[0]
+        return JsonArray(src.size).apply {
+            for (e in src) {
+                add(context.serialize(e, innerType))
+            }
+        }
+    }
+
+    override fun deserialize(json: JsonElement, typeOfT: Type, context: JsonDeserializationContext): ImmutableList<T> {
+        val par = typeOfT as ParameterizedType
+        val innerType = par.actualTypeArguments[0]
+        return json.array.lazy.map { e ->
+            context.deserialize<T>(e, innerType)
+        }.asIterable().toImmutableList()
+    }
+}
+
+class ImmutableMapTypeAdapter<K: Any, T: Any>: JsonSerializer<ImmutableMap<K, T>>, JsonDeserializer<ImmutableMap<K, T>> {
+    override fun serialize(src: ImmutableMap<K, T>, typeOfSrc: Type, context: JsonSerializationContext): JsonElement {
+        val par = typeOfSrc as ParameterizedType
+        val keyType = par.actualTypeArguments[0]
+        val valueType = par.actualTypeArguments[1]
+        return JsonArray(src.size).apply {
+            for ((key, value) in src) {
+                add(jsonArray(
+                    context.serialize(key, keyType),
+                    context.serialize(value, valueType)
+                ))
+            }
+        }
+    }
+
+    override fun deserialize(json: JsonElement, typeOfT: Type, context: JsonDeserializationContext): ImmutableMap<K, T> {
+        val par = typeOfT as ParameterizedType
+        val keyType = par.actualTypeArguments[0]
+        val valueType = par.actualTypeArguments[1]
+        return immutableMapOf(*json.array.map { e ->
+            val keyObj = e.array[0]
+            val valueObj = e.array[1]
+            context.deserialize<K>(keyObj, keyType) to
+                context.deserialize<T>(valueObj, valueType)
+        }.toTypedArray())
+    }
+}
+
+class ImmutableSetTypeAdapter<T: Any>: JsonSerializer<ImmutableSet<T>>, JsonDeserializer<ImmutableSet<T>> {
+    override fun serialize(src: ImmutableSet<T>, typeOfSrc: Type, context: JsonSerializationContext): JsonElement {
+        val par = typeOfSrc as ParameterizedType
+        val innerType = par.actualTypeArguments[0]
+        return JsonArray(src.size).apply {
+            for (e in src) {
+                add(context.serialize(e, innerType))
+            }
+        }
+    }
+
+    override fun deserialize(json: JsonElement, typeOfT: Type, context: JsonDeserializationContext): ImmutableSet<T> {
+        val par = typeOfT as ParameterizedType
+        val innerType = par.actualTypeArguments[0]
+        return json.array.lazy.map { e ->
+            context.deserialize<T>(e, innerType)
+        }.asIterable().toImmutableSet()
+    }
+}

--- a/app/src/main/java/com/loafofpiecrust/turntable/serialize/TypeRegistry.kt
+++ b/app/src/main/java/com/loafofpiecrust/turntable/serialize/TypeRegistry.kt
@@ -1,5 +1,6 @@
 package com.loafofpiecrust.turntable.serialize
 
+import com.github.salomonbrys.kotson.registerTypeAdapter
 import com.github.salomonbrys.kotson.typeAdapter
 import com.google.gson.Gson
 import com.google.gson.GsonBuilder
@@ -28,6 +29,9 @@ import com.loafofpiecrust.turntable.repository.remote.MusicBrainz
 import com.loafofpiecrust.turntable.repository.remote.Spotify
 import com.loafofpiecrust.turntable.sync.Sync
 import com.loafofpiecrust.turntable.sync.SyncSession
+import kotlinx.collections.immutable.ImmutableList
+import kotlinx.collections.immutable.ImmutableMap
+import kotlinx.collections.immutable.ImmutableSet
 import kotlinx.coroutines.channels.ConflatedBroadcastChannel
 import java.util.*
 
@@ -122,13 +126,7 @@ fun GsonBuilder.registerAllTypes() {
 
     registerTypeAdapter(ConflatedBroadcastChannel::class.java, CBCTypeAdapter<Any>())
     registerTypeAdapter(Date::class.java, DateTimestampSerializer())
-//    registerTypeAdapter<JsonObject> {
-//        serialize {
-//            it.src
-//        }
-//        deserialize {
-//            it.json.obj
-//        }
-//    }
-//            registerTypeAdapter(User::class.java, UserSerializer())
+    registerTypeAdapter(ImmutableList::class.java, ImmutableListTypeAdapter<Any>())
+    registerTypeAdapter(ImmutableSet::class.java, ImmutableSetTypeAdapter<Any>())
+    registerTypeAdapter(ImmutableMap::class.java, ImmutableMapTypeAdapter<Any, Any>())
 }

--- a/app/src/main/java/com/loafofpiecrust/turntable/sync/Sync.kt
+++ b/app/src/main/java/com/loafofpiecrust/turntable/sync/Sync.kt
@@ -14,10 +14,7 @@ import com.google.firebase.auth.FirebaseAuth
 import com.google.firebase.auth.FirebaseUser
 import com.google.firebase.iid.FirebaseInstanceId
 import com.google.gson.JsonObject
-import com.loafofpiecrust.turntable.App
-import com.loafofpiecrust.turntable.BuildConfig
-import com.loafofpiecrust.turntable.R
-import com.loafofpiecrust.turntable.appends
+import com.loafofpiecrust.turntable.*
 import com.loafofpiecrust.turntable.model.queue.isEmpty
 import com.loafofpiecrust.turntable.model.song.Song
 import com.loafofpiecrust.turntable.model.sync.Message
@@ -37,6 +34,7 @@ import io.ktor.client.request.url
 import io.ktor.client.response.HttpResponse
 import io.paperdb.Paper
 import kotlinx.android.parcel.Parcelize
+import kotlinx.collections.immutable.immutableListOf
 import kotlinx.coroutines.*
 import kotlinx.coroutines.channels.consumeEach
 import kotlinx.coroutines.channels.firstOrNull
@@ -54,7 +52,7 @@ object Sync {
     private const val SERVER_KEY = BuildConfig.FIREBASE_SERVER_KEY
 
     private val sendQueue by Paper.page("messagesToSend") {
-        listOf<Pair<Message, Mode>>()
+        immutableListOf<Pair<Message, Mode>>()
     }
 
     val selfUser = User()
@@ -160,7 +158,7 @@ object Sync {
 
     suspend fun send(msg: Message, mode: Sync.Mode): Boolean {
         if (App.currentInternetStatus.valueOrNull == App.InternetStatus.OFFLINE) {
-            sendQueue appends (msg to mode)
+            sendQueue putsMapped { it.add(msg to mode) }
             return false
         }
 
@@ -283,7 +281,7 @@ object Sync {
                     sendQueue.value.forEach { (msg, mode) ->
                         send(msg, mode)
                     }
-                    sendQueue.offer(listOf())
+                    sendQueue.offer(immutableListOf())
                 }
             }
         }

--- a/app/src/main/java/com/loafofpiecrust/turntable/views/SectionedRecyclerAdapter.kt
+++ b/app/src/main/java/com/loafofpiecrust/turntable/views/SectionedRecyclerAdapter.kt
@@ -27,6 +27,7 @@ abstract class SectionedRecyclerAdapter<T, R: Comparable<R>, VH: SectionedViewHo
             groupedData = value.groupBy(groupBy).toList().sortedBy { it.first }
             field = value
         }
+
     private val pendingUpdates = ArrayDeque<List<T>>()
 
     protected var groupedData: List<Pair<R, List<T>>> = listOf()


### PR DESCRIPTION
Replaces all uses of read-only lists and maps in channels because adding an element to one of these lists means copying the original first. By using immutable collections, we have constant overhead for adding an element no matter the size of the original collection.