### PR TITLE
Fix issues with queue operations

### DIFF
--- a/app/src/main/java/com/loafofpiecrust/turntable/album/AlbumDetailsUI.kt
+++ b/app/src/main/java/com/loafofpiecrust/turntable/album/AlbumDetailsUI.kt
@@ -79,7 +79,7 @@ open class AlbumDetailsUI(
 
     open val album: BroadcastChannel<Album> by lazy(LazyThreadSafetyMode.NONE) {
         Library.findAlbum(albumId).map {
-            it ?: Repositories.findOnline(albumId)!!
+            it ?: Repositories.findOnline(albumId) ?: EmptyAlbum(albumId)
         }.replayOne()
     }
 

--- a/app/src/main/java/com/loafofpiecrust/turntable/model/album/EmptyAlbum.kt
+++ b/app/src/main/java/com/loafofpiecrust/turntable/model/album/EmptyAlbum.kt
@@ -1,0 +1,13 @@
+package com.loafofpiecrust.turntable.model.album
+
+import com.loafofpiecrust.turntable.model.song.Song
+
+class EmptyAlbum(
+    override val id: AlbumId
+): Album {
+    override val year: Int get() = 0
+    override val type: Album.Type
+        get() = Album.Type.OTHER
+
+    override suspend fun resolveTracks(): List<Song> = emptyList()
+}

--- a/app/src/main/java/com/loafofpiecrust/turntable/player/MusicPlayer.kt
+++ b/app/src/main/java/com/loafofpiecrust/turntable/player/MusicPlayer.kt
@@ -40,8 +40,14 @@ class MusicPlayer(ctx: Context): Player.EventListener, CoroutineScope {
         SupervisorJob()
 
     enum class EnqueueMode {
-        NEXT, // Adds to the end of an "Up Next" section of the queue just after the current song.
-        IMMEDIATELY_NEXT, // Will play _immediately_ after the current song
+        /**
+         * Adds to the end of an "Up Next" section of the queue just after the current song.
+         */
+        NEXT,
+        /**
+         * Will play _immediately_ after the current song
+         */
+        IMMEDIATELY_NEXT,
     }
 
     private val bandwidthMeter = DefaultBandwidthMeter()
@@ -129,7 +135,8 @@ class MusicPlayer(ctx: Context): Player.EventListener, CoroutineScope {
     }
 
 
-    private val _isPlaying: ConflatedBroadcastChannel<Boolean> = ConflatedBroadcastChannel(false)
+    private val _isPlaying: ConflatedBroadcastChannel<Boolean> =
+        ConflatedBroadcastChannel(false)
     val isPlaying get() = _isPlaying.openSubscription()
     var isStreaming: Boolean = true
         private set
@@ -335,11 +342,14 @@ class MusicPlayer(ctx: Context): Player.EventListener, CoroutineScope {
     fun removeFromQueue(position: Int) {
         // TODO: Start with removing from nextUp, then from anywhere else if from StaticQueue (new interface method?)
 
-        if (_queue.value.indexWithinUpNext(position)) {
-            _queue putsMapped { q ->
-                val diff = if (q.isPlayingNext) 0 else 1
-                q.copy(nextUp = q.nextUp.without(position - q.position - diff))
-            }
+        val q = _queue.value
+        if (q.indexWithinUpNext(position)) {
+            val diff = if (q.isPlayingNext) 0 else 1
+            val indexToRemove = position - q.position - diff
+            _queue puts q.copy(nextUp = q.nextUp.without(indexToRemove))
+            mediaSource?.removeMediaSource(position)
+        } else {
+            Timber.e { "Cannot remove song from base queue" }
         }
     }
 
@@ -453,12 +463,11 @@ class MusicPlayer(ctx: Context): Player.EventListener, CoroutineScope {
         if (alreadyPlaying) {
             totalListenedTime += player.currentPosition - lastResumeTime
             player.playWhenReady = false
-//            _isPlaying puts false
         }
         return alreadyPlaying
     }
 
-    //    @Synchronized
+
     fun togglePause(): Boolean {
         return if (player.playWhenReady) {
             pause()
@@ -494,7 +503,7 @@ class MusicPlayer(ctx: Context): Player.EventListener, CoroutineScope {
         // TODO: Decide on percent threshold to count as a "full" listen. Is half the song enough?
         private const val LISTENED_PROPORTION = 0.5
         private const val USER_AGENT = "Mozilla/5.0 (X11; Linux x86_64; rv:58.0) Gecko/20100101 Firefox/58.0"
-        val THREAD_CONTEXT = newSingleThreadContext("music-player")
+//        val THREAD_CONTEXT = newSingleThreadContext("music-player")
 //        val THREAD_CONTEXT = Dispatchers.Main
     }
 }

--- a/app/src/main/java/com/loafofpiecrust/turntable/player/MusicPlayer.kt
+++ b/app/src/main/java/com/loafofpiecrust/turntable/player/MusicPlayer.kt
@@ -170,8 +170,10 @@ class MusicPlayer(ctx: Context): Player.EventListener, CoroutineScope {
     override fun onPlaybackParametersChanged(playbackParameters: PlaybackParameters?) {
     }
 
-    override fun onTracksChanged(trackGroups: TrackGroupArray?, trackSelections: TrackSelectionArray?) {
-
+    override fun onTracksChanged(
+        trackGroups: TrackGroupArray?,
+        trackSelections: TrackSelectionArray?
+    ) {
     }
 
     private var errorCount = 0
@@ -186,9 +188,13 @@ class MusicPlayer(ctx: Context): Player.EventListener, CoroutineScope {
         // if that fails the 2nd time, skip to the next track in the MediaSource.
         if (error.type == ExoPlaybackException.TYPE_SOURCE) {
             App.instance.toast("Song not available to stream")
-            // to retry, we have to rebuild the MediaSource
-            playNext()
-            prepareSource()
+            if (hasNext) {
+                // to retry, we have to rebuild the MediaSource
+                playNext()
+                prepareSource()
+            } else {
+                temporaryPause()
+            }
         } else {
             App.instance.toast("Dubious player error (type ${error.type})")
         }

--- a/app/src/main/java/com/loafofpiecrust/turntable/player/MusicService.kt
+++ b/app/src/main/java/com/loafofpiecrust/turntable/player/MusicService.kt
@@ -188,7 +188,8 @@ class MusicService : BaseService(), OnAudioFocusChangeListener {
                 val queue = runBlocking {
                     this@MusicService.player.queue.first()
                 }
-                val song = queue.list[windowIndex]
+                val idx = minOf(windowIndex, queue.list.size - 1)
+                val song = queue.list[idx]
                 return MediaDescriptionCompat.Builder()
                     .setTitle(song.id.displayName)
                     .setSubtitle(song.id.artist.displayName)


### PR DESCRIPTION
- Removing items from the queue now removes them from the inner `ExoPlayer` media source.
- Reaching the end of the queue with a track that can't play now actually stops.